### PR TITLE
removing upgrade steps

### DIFF
--- a/ztp-chef.sh
+++ b/ztp-chef.sh
@@ -26,7 +26,6 @@ $(rm -f /var/lib/apt/lists/partial/* /var/lib/apt/lists/* 2>/dev/null; true)
 
 # Upgrade and install Chef
 apt-get update -y
-apt-get upgrade -y
 
 apt-get install curl chef -y
 

--- a/ztp-puppet.sh
+++ b/ztp-puppet.sh
@@ -26,7 +26,6 @@ $(rm -f /var/lib/apt/lists/partial/* /var/lib/apt/lists/* 2>/dev/null; true)
 
 # Upgrade and install Puppet
 apt-get update -y
-apt-get upgrade -y
 apt-get install puppet -y
 
 echo "Configuring puppet" | wall -n


### PR DESCRIPTION
apt-get upgrade can break when new releases happen.  Possibly merge after email discussion is finished