### PR TITLE
CE-1055 Remove CM-3812 workaround

### DIFF
--- a/ztp-ansible.sh
+++ b/ztp-ansible.sh
@@ -9,9 +9,6 @@ exec >/var/log/autoprovision 2>&1
 
 trap error ERR
 
-# Workaround for CM-3812; clean out the apt cache before we run apt-get update
-$(rm -f /var/lib/apt/lists/partial/* /var/lib/apt/lists/* 2>/dev/null; true)
-
 URL="http://wbench.lab.local/authorized_keys"
 
 mkdir -p /root/.ssh

--- a/ztp-chef.sh
+++ b/ztp-chef.sh
@@ -21,9 +21,6 @@ mkdir -p /home/cumulus/.ssh
 /usr/bin/wget -O /home/cumulus/.ssh/authorized_keys $URL
 chown -R cumulus:cumulus /home/cumulus/.ssh
 
-# Workaround for CM-3812; clean out the apt cache before we run apt-get update
-$(rm -f /var/lib/apt/lists/partial/* /var/lib/apt/lists/* 2>/dev/null; true)
-
 # Upgrade and install Chef
 apt-get update -y
 

--- a/ztp-puppet.sh
+++ b/ztp-puppet.sh
@@ -21,9 +21,6 @@ mkdir -p /home/cumulus/.ssh
 /usr/bin/wget -O /home/cumulus/.ssh/authorized_keys $URL
 chown -R cumulus:cumulus /home/cumulus/.ssh
 
-# Workaround for CM-3812; clean out the apt cache before we run apt-get update
-$(rm -f /var/lib/apt/lists/partial/* /var/lib/apt/lists/* 2>/dev/null; true)
-
 # Upgrade and install Puppet
 apt-get update -y
 apt-get install puppet -y


### PR DESCRIPTION
The bug reported in CM-3812 was fixed in release 2.2.2, so the workaround
shouldn't be required as we don't use anything that old in the workbench any
more.